### PR TITLE
[add] support to get only the runnable thread stack traces.

### DIFF
--- a/spf4j-core/src/main/java/org/spf4j/stackmonitor/ObservableStackCollector.java
+++ b/spf4j-core/src/main/java/org/spf4j/stackmonitor/ObservableStackCollector.java
@@ -50,7 +50,7 @@ public final class ObservableStackCollector extends AbstractStackCollector {
   private Thread[] requestFor = new Thread[]{};
 
   public ObservableStackCollector(final boolean collectForMain, final String... xtraIgnoredThreads) {
-    this(FastStackCollector.createNameBasedFilter(collectForMain, xtraIgnoredThreads));
+    this(FastStackCollector.createNameBasedFilter(false, collectForMain, xtraIgnoredThreads));
   }
 
   public ObservableStackCollector(final Predicate<Thread> threadFilter) {


### PR DESCRIPTION
While gathering info on flamegraphs I looked at the way they do it in stackcollapse-jstack.pl and noticed that they usually care about the RUNNABLE threads. After doing several compares I came to the conclusion that for most cases this would improve memory as well as give us the most important data.

This code should be backwards compatible.