### PR TITLE
Make RecorderSourceInstance extendable from user's code.

### DIFF
--- a/spf4j-aspects/src/main/java/org/spf4j/annotations/RecorderSourceInstance.java
+++ b/spf4j-aspects/src/main/java/org/spf4j/annotations/RecorderSourceInstance.java
@@ -42,9 +42,6 @@ import org.spf4j.perf.impl.NopMeasurementRecorderSource;
 
 public abstract class RecorderSourceInstance {
 
-    private RecorderSourceInstance() {
-    }
-
     public static final class RsNop extends RecorderSourceInstance {
 
         public static final MeasurementRecorderSource INSTANCE = NopMeasurementRecorderSource.INSTANCE;


### PR DESCRIPTION
User need to be able to expand the functionality of @PerformanceMonitor. Having RecorderSourceInstance extendable is one way to do so.