### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <java8.home>/Library/Java/JavaVirtualMachines/jdk1.8.0_261.jdk/Contents/Home</java8.home>
     <java11.home>/Library/Java/JavaVirtualMachines/jdk-11.0.8.jdk/Contents/Home</java11.home>
     <skip.forbidenApi>false</skip.forbidenApi>
-  	<closeTestReports>true</closeTestReports>
+    <surefire.disableXmlReport>true</surefire.disableXmlReport>
   </properties>
 
   <scm>
@@ -293,7 +293,7 @@
                 <jvm>${user.home}/jdk/jdk8u181-b13/bin/java</jvm>
                 <parallel>classes</parallel>
                 <useUnlimitedThreads>true</useUnlimitedThreads>
-                <disableXmlReport>${closeTestReports}</disableXmlReport>
+                <disableXmlReport>${surefire.disableXmlReport}</disableXmlReport>
               </configuration>
             </plugin>
           </plugins>
@@ -312,7 +312,7 @@
                 <jvm>${java11.home}/bin/java</jvm>
                 <parallel>classes</parallel>
                 <useUnlimitedThreads>true</useUnlimitedThreads>
-                <disableXmlReport>${closeTestReports}</disableXmlReport>
+                <disableXmlReport>${surefire.disableXmlReport}</disableXmlReport>
               </configuration>
             </plugin>
             <plugin>
@@ -704,7 +704,7 @@ java.util.Calendar#getInstance()
             <jvm>${java8.home}/bin/java</jvm>
             <parallel>classes</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
-            <disableXmlReport>${closeTestReports}</disableXmlReport>
+            <disableXmlReport>${surefire.disableXmlReport}</disableXmlReport>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <java8.home>/Library/Java/JavaVirtualMachines/jdk1.8.0_261.jdk/Contents/Home</java8.home>
     <java11.home>/Library/Java/JavaVirtualMachines/jdk-11.0.8.jdk/Contents/Home</java11.home>
     <skip.forbidenApi>false</skip.forbidenApi>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,7 @@
                 <jvm>${user.home}/jdk/jdk8u181-b13/bin/java</jvm>
                 <parallel>classes</parallel>
                 <useUnlimitedThreads>true</useUnlimitedThreads>
+                <disableXmlReport>${closeTestReports}</disableXmlReport>
               </configuration>
             </plugin>
           </plugins>
@@ -311,6 +312,7 @@
                 <jvm>${java11.home}/bin/java</jvm>
                 <parallel>classes</parallel>
                 <useUnlimitedThreads>true</useUnlimitedThreads>
+                <disableXmlReport>${closeTestReports}</disableXmlReport>
               </configuration>
             </plugin>
             <plugin>
@@ -702,6 +704,7 @@ java.util.Calendar#getInstance()
             <jvm>${java8.home}/bin/java</jvm>
             <parallel>classes</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
+            <disableXmlReport>${closeTestReports}</disableXmlReport>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
